### PR TITLE
ETL 65 generate home directory

### DIFF
--- a/-inputs.tf
+++ b/-inputs.tf
@@ -25,3 +25,8 @@ variable "name_suffix" {
   type        = string
   default     = ""
 }
+
+
+variable s3_bucket_name {
+  description = "Name of the S3 bucket to connect SFTP server to."
+}

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+# JetBrains IDEs
+.idea

--- a/default_iam_role.tf
+++ b/default_iam_role.tf
@@ -1,0 +1,60 @@
+# Content of this file was copied from:
+# https://github.com/StratusGrid/terraform-aws-transfer-server-custom-idp-user/blob/main/main.tf
+
+resource aws_iam_role default {
+  name = "${var.name_prefix}-sftp-transfer-server-user-default-role${var.name_suffix}"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        Effect: "Allow",
+        Principal: {
+          Service: "transfer.amazonaws.com"
+        },
+        Action : "sts:AssumeRole"
+      }
+    ]
+  })
+  tags = merge(
+    var.input_tags,
+    {
+      Name: "${var.name_prefix}-sftp-transfer-server-user-default-role${var.name_suffix}"
+    },
+  )
+}
+
+resource "aws_iam_role_policy" "sftp_transfer_server_user" {
+  name = "${var.name_prefix}-sftp-transfer-server-user-default-iam-policy${var.name_suffix}"
+  role = aws_iam_role.default.id
+
+  policy = jsonencode({
+    "Version" = "2012-10-17",
+    "Statement" = [
+      {
+        Action: [
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Effect: "Allow"
+        Resource: [
+          "arn:aws:s3:::${var.s3_bucket_name}",
+        ]
+        Sid = "AllowListingOfUserFolder"
+      },
+      {
+        Action = [
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:GetObject",
+          "s3:DeleteObjectVersion",
+          "s3:DeleteObject",
+          "s3:GetObjectVersion",
+        ]
+        Effect   = "Allow"
+        Resource = "arn:aws:s3:::${var.s3_bucket_name}*"
+        Sid      = "HomeDirObjectAccess"
+      },
+    ]
+  })
+}

--- a/files/sftp_lambda.py
+++ b/files/sftp_lambda.py
@@ -54,8 +54,7 @@ def lambda_handler(event, context):
     if 'Role' in resp_dict:
         resp_data['Role'] = resp_dict['Role']
     else:
-        print("No field match for role - Set empty string in response")
-        resp_data['Role'] = ''
+        resp_data['Role'] = os.getenv('DEFAULT_IAM_ROLE_ARN')
 
     # These are optional so ignore if not present
     if 'Policy' in resp_dict:
@@ -73,6 +72,7 @@ def lambda_handler(event, context):
 
     print("Completed Response Data: "+json.dumps(resp_data))
     return resp_data
+
 
 def get_secret(id):
     region = os.environ['SecretsManagerRegion']

--- a/files/sftp_lambda.py
+++ b/files/sftp_lambda.py
@@ -105,11 +105,12 @@ def lambda_handler(event, _context):
     if 'Policy' in resp_dict:
         resp_data['Policy'] = resp_dict['Policy']
 
+    home_directory = resp_dict['HomeDirectory']
     if not resp_data['Role']:
         resp_data['Role'] = os.getenv('DEFAULT_IAM_ROLE_ARN')
         resp_data['Policy'] = json.dumps(construct_policy(
             bucket_name=bucket_name,
-            home_directory=resp_dict['HomeDirectory'],
+            home_directory=home_directory,
         ))
 
     if 'HomeDirectoryDetails' in resp_dict:
@@ -121,7 +122,7 @@ def lambda_handler(event, _context):
 
     elif 'HomeDirectory' in resp_dict:
         print("HomeDirectory found - Cannot be used with HomeDirectoryDetails")
-        resp_data['HomeDirectory'] = resp_dict['HomeDirectory']
+        resp_data['HomeDirectory'] = f'/{bucket_name}/{home_directory}'
 
     else:
         print("HomeDirectory not found - Defaulting to /")

--- a/files/sftp_lambda.py
+++ b/files/sftp_lambda.py
@@ -115,8 +115,8 @@ def lambda_handler(event, _context):
         return {}
 
     if input_password != '':
-        if 'Password' in resp_dict:
-            resp_password = resp_dict['Password']
+        if 'password' in resp_dict:
+            resp_password = resp_dict['password']
         else:
             print(
                 "Unable to authenticate user - No field match in Secret for password")

--- a/files/sftp_lambda.py
+++ b/files/sftp_lambda.py
@@ -107,10 +107,10 @@ def lambda_handler(event, _context):
 
     if not resp_data['Role']:
         resp_data['Role'] = os.getenv('DEFAULT_IAM_ROLE_ARN')
-        resp_data['Policy'] = construct_policy(
+        resp_data['Policy'] = json.dumps(construct_policy(
             bucket_name=bucket_name,
             home_directory=resp_dict['HomeDirectory'],
-        )
+        ))
 
     if 'HomeDirectoryDetails' in resp_dict:
         print(

--- a/files/sftp_lambda.py
+++ b/files/sftp_lambda.py
@@ -123,10 +123,10 @@ def lambda_handler(event, _context):
         print("HomeDirectory found - Cannot be used with HomeDirectoryDetails")
         resp_data['HomeDirectory'] = f'/{bucket_name}/{home_directory}'
 
-    resp_data['HomeDirectoryType'] = "LOGICAL"
-
     else:
         print("HomeDirectory not found - Defaulting to /")
+
+    resp_data['HomeDirectoryType'] = "LOGICAL"
 
     print("Completed Response Data: " + json.dumps(resp_data))
     return resp_data

--- a/files/sftp_lambda.py
+++ b/files/sftp_lambda.py
@@ -118,11 +118,12 @@ def lambda_handler(event, _context):
             "HomeDirectoryDetails found - Applying setting for virtual folders",
         )
         resp_data['HomeDirectoryDetails'] = resp_dict['HomeDirectoryDetails']
-        resp_data['HomeDirectoryType'] = "LOGICAL"
 
     elif 'HomeDirectory' in resp_dict:
         print("HomeDirectory found - Cannot be used with HomeDirectoryDetails")
         resp_data['HomeDirectory'] = f'/{bucket_name}/{home_directory}'
+
+    resp_data['HomeDirectoryType'] = "LOGICAL"
 
     else:
         print("HomeDirectory not found - Defaulting to /")

--- a/files/sftp_lambda.py
+++ b/files/sftp_lambda.py
@@ -126,7 +126,12 @@ def lambda_handler(event, _context):
     else:
         print("HomeDirectory not found - Defaulting to /")
 
-    resp_data['HomeDirectoryType'] = "LOGICAL"
+    resp_data['HomeDirectoryType'] = 'LOGICAL'
+    resp_data['HomeDirectoryDetails'] = json.dumps([{
+        'Entry': '/',
+        'Target': f'/{bucket_name}/{home_directory}',
+    }])
+    del resp_data['HomeDirectory']
 
     print("Completed Response Data: " + json.dumps(resp_data))
     return resp_data

--- a/lambda.tf
+++ b/lambda.tf
@@ -21,6 +21,8 @@ resource "aws_lambda_function" "sftp" {
   environment {
     variables = {
       "SecretsManagerRegion" = var.region
+      DEFAULT_IAM_ROLE_ARN = aws_iam_role.default.arn
+      BUCKET_NAME = var.s3_bucket_name
     }
   }
   tags = merge(

--- a/lambda.tf
+++ b/lambda.tf
@@ -20,7 +20,8 @@ resource "aws_lambda_function" "sftp" {
   timeouts {}
   environment {
     variables = {
-      "SecretsManagerRegion" = var.region
+      SecretsManagerRegion = var.region
+
       DEFAULT_IAM_ROLE_ARN = aws_iam_role.default.arn
       BUCKET_NAME = var.s3_bucket_name
     }

--- a/lambda.tf
+++ b/lambda.tf
@@ -14,10 +14,14 @@ resource "aws_lambda_function" "sftp" {
   handler          = "sftp_lambda.lambda_handler"
   runtime          = "python3.7"
   source_code_hash = filebase64sha256(data.archive_file.sftp_lambda.output_path)
+  reserved_concurrent_executions = 5
+
   tracing_config {
     mode = "PassThrough"
   }
+
   timeouts {}
+
   environment {
     variables = {
       SecretsManagerRegion = var.region
@@ -26,6 +30,7 @@ resource "aws_lambda_function" "sftp" {
       BUCKET_NAME = var.s3_bucket_name
     }
   }
+
   tags = merge(
     var.input_tags,
     {


### PR DESCRIPTION
- ETL-35 Create a default IAM role applicable to any user
- ETL-203 Generate a policy
- ETL-203 Serialize policy as string
- ETL-203 Use bucket name in home directory
- ETL-10 Add `reserved_concurrent_executions` to the λ function
- ETL-161 Fill in `HomeDirectoryType`
- ETL-161 Fix a stupid syntax error
- ETL-161 Use `HomeDirectoryDetails` field
- ETL-65 Hardcode home directory path generation
