### PR TITLE
ETL 216 public key

### DIFF
--- a/transfer_server_custom_idp/models.py
+++ b/transfer_server_custom_idp/models.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import BaseModel, Field
 
@@ -9,3 +9,14 @@ class Login(BaseModel):
     username: str
     server_id: str = Field(alias='serverId')
     password: Optional[str]
+
+
+class AWSTransferResponse(BaseModel):
+    """Authentication response."""
+
+    public_keys: Optional[List[str]] = Field(None, alias='PublicKeys')
+
+    class Config:
+        """Allow sane initialization."""
+
+        allow_population_by_field_name = True


### PR DESCRIPTION
- ETL-199 Throw a special exception when user is not found
- ETL-199 Update `build.zip`
- ETL-199 Connect with `structlog`
- ETL-199 Introduce `Login` model
- ETL-199 Insert missing alias of `server_id` → `serverId`
- ETL-199 CloudWatch log is not strictly JSON because of stdlib `logging` formatting
- ETL-199 Return successful auth message and log exceptions
- ETL-199 Print raw event
- ETL-199 No need to print event any more
- ETL-199 KeyError: `level`
- ETL-199 Use `SentryJsonProcessor`
- ETL-199 A few more error classes to add
- ETL-199 Try `render_to_log_kwargs`
- ETL-199 `render_to_log_kwargs` must go after `structlog-sentry`
- ETL-199 Try to force `logging` into formatting the output properly
- ETL-216 Support `key` field
